### PR TITLE
Profiles Cleanup

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -3,6 +3,7 @@ class FeedsController < ApplicationController
   def main_feed
     # This is so we have the users' name with the post instead of just their id's.
     @posts = Post.joins(:user)
+                 .includes(:user)
                  .select('posts.*, users.id as user_id, users.name as user_name')
                  .order(created_at: :desc)
                  .page(params[:page])

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,10 +1,9 @@
 class ProfilesController < ApplicationController
   def show
+    @profile = Profile.includes([:user]).find_by(user_id: params[:user_id])
+    @posts = Post.where(user_id: @profile.user_id).includes([:user]).page(params[:page]).per(15) if @profile
     respond_to do |format|
       format.html do
-        @profile = Profile.includes(user: :posts).find_by(user_id: params[:user_id])
-        @posts = Post.where(user_id: @profile.user_id).page(params[:page]).per(15) if @profile
-
         @post = Post.new
 
         render :show # implicit if removed bc name match, but wanted to be explicit while debugging
@@ -14,11 +13,10 @@ class ProfilesController < ApplicationController
   end
 
   def friends
+    @user_id = params[:user_id]
+    @friendships = User.find(@user_id).mutual_friendships.includes(friend: :profile).page(params[:page]).per(15)
     respond_to do |format|
       format.html do
-        @user_id = params[:user_id]
-        @friendships = User.find(@user_id).mutual_friendships.includes(friend: :profile)
-
         render :friends # implicit if removed bc name match, but wanted to be explicit while debugging
       end
       format.turbo_stream

--- a/app/views/friendships/_friendship.html.erb
+++ b/app/views/friendships/_friendship.html.erb
@@ -1,6 +1,6 @@
 <div class="friendship">
   <span class="text-blue-500">
-    <%= link_to friendship.friend.name, user_profile_path(friendship.friend.id), data: {turbo: false} %>
+    <%= link_to "#{friendship.friend.name}", user_profile_path(friendship.friend.id), data: {turbo: false} %>
     
   </span>
   - <%=friendship.friend.profile.slug %>

--- a/app/views/profiles/friends.html.erb
+++ b/app/views/profiles/friends.html.erb
@@ -1,5 +1,8 @@
 <%= turbo_frame_tag 'content', class: 'marble-background' do %>
   <div id='friends' class="border-x border-yellow-600 divide-y divide-yellow-600">
     <%= render 'friendships/friendships', friendships: @friendships %>
+    <% unless @friendships.last_page? %>
+      <%= turbo_frame_tag 'loading-friendships', src: friends_user_profile_path(page: @friendships.next_page, format: :turbo_stream), loading: :lazy %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/profiles/friends.turbo_stream.erb
+++ b/app/views/profiles/friends.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.append 'content' do %>
+  <%= render partial: 'friendships/friendships', collection: @friendships %>
+<% end %>
+
+<% unless @friendships.last_page? %>
+    <%= turbo_stream.replace 'loading-friendships' do %>
+        <%= turbo_frame_tag 'loading-friendships', src: friends_user_profile_path(page: @friendships.next_page, format: :turbo_stream), loading: :lazy %>
+    <% end %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -30,6 +30,7 @@
     <%= turbo_frame_tag 'content', class: 'marble-background' do %>
       <div id='posts'>
         <%= render partial: 'posts/post', collection: @posts %>
+        <%= turbo_frame_tag 'loading-posts', src: user_profile_path(page: @posts.next_page, format: :turbo_stream), loading: :lazy %>
       </div>
     <% end %>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -34,6 +34,4 @@
       </div>
     <% end %>
   </div>
-  
 </div>
-<div id='settings' class='fixed right-8'>Settings</div>

--- a/app/views/profiles/show.turbo_stream.erb
+++ b/app/views/profiles/show.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.append 'content' do %>
+  <%= render partial: 'posts/post', collection: @posts %>
+<% end %>
+
+<% unless @posts.last_page? %>
+    <%= turbo_stream.replace 'loading-posts' do %>
+        <%= turbo_frame_tag 'loading-posts', src: user_profile_path(page: @posts.next_page, format: :turbo_stream), loading: :lazy %>
+    <% end %>
+<% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,7 +1,7 @@
 <nav class="fixed">
   <ul class='divide-y divide-yellow-600 m-4'>
     <li class='hover:bg-slate-100/50 rounded-lg'><%= link_to 'Home', root_path %></li>
-    <li class='hover:bg-slate-100/50 rounded-lg'><%= link_to 'Profile'%></li>
+    <li class='hover:bg-slate-100/50 rounded-lg'><%= link_to 'Profile', user_profile_path(current_user.id)%></li>
     <li><%= link_to 'Friendships', friendships_path %></li>
     <li class='hover:bg-slate-100/50 rounded-lg'><%= link_to 'Logout', logout_path%></li>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   get 'login',         to: 'sessions#new'
   post 'login',        to: 'sessions#create'
 
-  get 'logout', to: 'sessions#destroy'
+  delete 'logout', to: 'sessions#destroy'
 
   # visitable pages
   resources :users, only: %i[new create show] do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
 
     trait :with_posts do
       after :create do |user|
-        3.times { create :post, user: user, text: 'This is a post.' }
+        create_list(:post, 3, user: user, text: 'This is a post.')
       end
     end
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,9 +11,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_mutual_friends do
+      after :create do |user|
+        create :friendship, user: user, friend: create(:user), mutual: true
+        create :friendship, user: user, friend: create(:user), mutual: true
+      end
+    end
+
     trait :with_posts do
       after :create do |user|
-        create :post, user: user, text: 'This is a post.'
+        3.times { create :post, user: user, text: 'This is a post.' }
       end
     end
   end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+describe 'Profiles' do
+  let!(:user_one) { create(:user, :with_posts, :with_mutual_friends) }
+  let!(:user_two) { create(:user, :with_posts, :with_mutual_friends) }
+
+  before do
+    post login_url, params: { password: user_one.password, email: user_one.email }
+  end
+
+  describe 'GET /profile' do
+    context "when viewing the current_user's profile" do
+      before do
+        get user_profile_path(user_id: user_one.id)
+      end
+
+      it 'returns an :ok status code' do
+        expect(response).to have_http_status :ok
+      end
+
+      it "shows the list of the current_user's posts" do
+        expect(response.body).to include(user_one.posts.first.text)
+      end
+    end
+
+    context "when viewing another user's profile" do
+      before do
+        get user_profile_path(user_id: user_two.id)
+      end
+
+      it 'returns an :ok status code' do
+        expect(response).to have_http_status :ok
+      end
+
+      it "shows the list of the selected user's posts" do
+        expect(response.body).to include(user_two.posts.first.text)
+      end
+    end
+  end
+
+  describe 'GET /friends' do
+    before do
+      post login_url, params: { password: user_one.password, email: user_one.email }
+    end
+
+    context "when on the current_user's profile" do
+      before do
+        get user_profile_path(user_id: user_one.id)
+        get friends_user_profile_path(user_id: user_one.id)
+      end
+
+      it 'returns an :ok status code' do
+        expect(response).to have_http_status :ok
+      end
+
+      # it 'returns a turbo_stream response' do
+      #   expect(response.media_type).to eq Mime[:turbo_stream]
+      # end
+
+      it 'shows the mutual friendships of the current_user' do
+        expect(response.body).to include(user_one.friends.first.name)
+      end
+    end
+
+    context "when on another user's profile" do
+      before do
+        get user_profile_path(user_id: user_two.id)
+        get friends_user_profile_path(user_id: user_two.id)
+      end
+
+      it 'returns an :ok status code' do
+        expect(response).to have_http_status :ok
+      end
+
+      it 'shows the mutual friendships of the selected user' do
+        expect(response.body).to include(user_two.friends.first.name)
+      end
+    end
+  end
+
+  describe '#edit: GET /edit' do
+    context "when on the current_user's profile" do
+      it 'renders the edit form for the profile page' do
+        skip('view has yet to be created')
+      end
+    end
+
+    context "when on another user's profile" do
+      it 'returns an :unauthorized as it should not be possible' do
+        skip('view has yet to be created')
+      end
+    end
+  end
+
+  describe ':update: PUT /edit' do
+    context "when on the current_user's profile" do
+      it "renders the view for the current user's profile" do
+        skip('view has yet to be created')
+      end
+    end
+
+    context "when on another user's profile" do
+      it 'returns an :unauthorized as it should not be possible' do
+        skip('view has yet to be created')
+      end
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -30,7 +30,7 @@ describe 'Sessions' do
     end
   end
 
-  describe 'DELETE /destroy', skip: 'currently broken' do
+  describe 'DELETE /destroy' do
     before { delete logout_path }
 
     it 'removes the user id from the session' do


### PR DESCRIPTION
Minor cleanup stuff:
fixing some N+1/eager loading bugs
fixing endless scroll on main feed and profile feeds.
Tweak some factories for tests and added some new ones for profiles
Edit/Update tests for profiles are currently skipped, to be completed in subsequent PR.
Fixes the bug with the logout path and the relevant tests.